### PR TITLE
Fix v1beta1 -> v1 version for ClusterRoleBinding

### DIFF
--- a/helm/rbac-config.yml
+++ b/helm/rbac-config.yml
@@ -4,7 +4,7 @@ metadata:
   name: tiller
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tiller


### PR DESCRIPTION
rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding